### PR TITLE
feat: set dark theme as default

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -145,6 +145,11 @@ const config: Config = {
       theme: prismThemes.dracula,
       darkTheme: prismThemes.dracula,
     },
+    colorMode: {
+      defaultMode: 'dark',
+      disableSwitch: false,
+      respectPrefersColorScheme: false,
+    },
   } satisfies Preset.ThemeConfig,
 };
 


### PR DESCRIPTION
Changed the default theme setting in docusaurus.config.js to enable dark mode as the default theme.
